### PR TITLE
Fixed indentation issue for python code

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,4 @@ Make sure to use triple quotes as it will preserve the code format.
 - Run the script `python3 simulate_keyboard.py`
 - The script will start typing after 3s (you can change the wait time or delay)
 - After running the script click on the window wherever you want to auto-type.
-  
-**Note**: You may have to adjust indents manually if you autotype a python file. 
+ 

--- a/simulate_keyboard.py
+++ b/simulate_keyboard.py
@@ -12,8 +12,10 @@ def type(path=None, delay=None):
     
     # manually enter your code here or provide a path
     code = """
-            Enter the code to be autotyped 
-            here or provide a path to the file 
+class Complex:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
     """
     if path:
         with open(path, 'r') as file:
@@ -21,7 +23,10 @@ def type(path=None, delay=None):
             print(code)
         
     keyboard = Controller()
-    keyboard.type(code)
+    for line in code.split('\n'):
+        keyboard.type(line)
+        keyboard.tap(Key.enter)
+        keyboard.tap(Key.home)
     
 if __name__ == '__main__':
     parser = ArgumentParser(description='Autotype the specified file')

--- a/simulate_keyboard.py
+++ b/simulate_keyboard.py
@@ -20,7 +20,6 @@ class Complex:
     if path:
         with open(path, 'r') as file:
             code = file.read()
-            print(code)
         
     keyboard = Controller()
     for line in code.split('\n'):


### PR DESCRIPTION
In order to avoid excessive Indentation #1 , program will type code line by line instead of typing whole code at once. This  can be done by spliting the code by new line character `\n`, type that line then press `Enter` key for next line and then press `Home` to move the cursor at the start of the line and repeat the same process.

It is a bit slower but working fine.